### PR TITLE
Add TutorialSearch to Online courses

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,6 +362,7 @@ List of useful resources for frontend developers
 - [Codecademy](https://www.codecademy.com/)
 - [Khan Academy](https://www.khanacademy.org/computing/computer-programming)
 - [Code School](https://www.codeschool.com/)
+- [TutorialSearch](https://tutorialsearch.io/) - Free cross-platform search engine indexing 50,000+ tutorials from Udemy, Skillshare, Pluralsight, and other major learning platforms across 45+ categories.
 - [Udacity](https://www.udacity.com/courses/web-development)
 - [freeCodeCamp](https://www.freecodecamp.com/)
 - [Udemy](https://www.udemy.com/)

--- a/README.md
+++ b/README.md
@@ -362,7 +362,7 @@ List of useful resources for frontend developers
 - [Codecademy](https://www.codecademy.com/)
 - [Khan Academy](https://www.khanacademy.org/computing/computer-programming)
 - [Code School](https://www.codeschool.com/)
-- [TutorialSearch](https://tutorialsearch.io/) - Free cross-platform search engine indexing 50,000+ tutorials from Udemy, Skillshare, Pluralsight, and other major learning platforms across 45+ categories.
+- [TutorialSearch](https://tutorialsearch.io/browse/web-development/front-end-development) - Free cross-platform search engine indexing 50,000+ tutorials from Udemy, Skillshare, Pluralsight, and other major learning platforms across 45+ categories.
 - [Udacity](https://www.udacity.com/courses/web-development)
 - [freeCodeCamp](https://www.freecodecamp.com/)
 - [Udemy](https://www.udemy.com/)


### PR DESCRIPTION
Hi! This PR adds **TutorialSearch** to the *Online courses* section.

### What is TutorialSearch?
[TutorialSearch](https://tutorialsearch.io/browse/web-development/front-end-development) is a free, cross-platform search engine that indexes 50,000+ tutorials and courses from major learning platforms (Udemy, Skillshare, Pluralsight, and more) across 45+ categories — including programming, web development, AI/ML, cybersecurity, design, and more. No signup required.

It helps learners compare tutorials side-by-side by rating, price, and reviews before committing to a course, which I think makes it a useful addition to this list.

### Entry added
```
- [TutorialSearch](https://tutorialsearch.io/browse/web-development/front-end-development) - Free cross-platform search engine indexing 50,000+ tutorials from Udemy, Skillshare, Pluralsight, and other major learning platforms across 45+ categories.
```

Inserted in alphabetical order within the section. Happy to adjust formatting, description length, or placement if you'd like — just let me know!

Thanks for maintaining this list.